### PR TITLE
CI: Use actions/checkout@v3

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -37,7 +37,7 @@ jobs:
             experimental: true
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}

--- a/template/actions/.github/workflows/development.yml
+++ b/template/actions/.github/workflows/development.yml
@@ -37,7 +37,7 @@ jobs:
             experimental: true
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}


### PR DESCRIPTION
This is a very minor change. Now, all Workflows in this repo use this
version of this Action.