### PR TITLE
Add gemspec metadata fields

### DIFF
--- a/bake/modernize/gemspec.rb
+++ b/bake/modernize/gemspec.rb
@@ -233,9 +233,22 @@ def detect_changelog_uri(spec)
 		root = File.dirname(spec.loaded_from)
 		
 		if File.exist?(File.expand_path("releases.md", root))
-			return "https://github.com/#{account}/#{project}/blob/main/releases.md"
+			branch = current_branch(root) || "main"
+			
+			return "https://github.com/#{account}/#{project}/blob/#{branch}/releases.md"
 		end
 	end
+end
+
+def current_branch(root)
+	repository = Rugged::Repository.discover(root)
+	head = repository.head
+	
+	if head.branch?
+		return head.name.delete_prefix("refs/heads/")
+	end
+rescue Rugged::ReferenceError, Rugged::RepositoryError
+	# Fall back to the common default branch name when git metadata is unavailable.
 end
 
 def detect_funding_uri(spec)

--- a/bake/modernize/gemspec.rb
+++ b/bake/modernize/gemspec.rb
@@ -31,9 +31,7 @@ def update(path: default_gemspec_path, output: $stdout)
 	
 	normalize_homepage(spec)
 	
-	spec.metadata["funding_uri"] ||= detect_funding_uri(spec)
-	spec.metadata["documentation_uri"] ||= detect_documentation_uri(spec)
-	spec.metadata["source_code_uri"] ||= detect_source_code_uri(spec)
+	update_metadata(spec)
 	
 	spec.authors = sorted_authors(Dir.pwd)
 	
@@ -199,14 +197,49 @@ end
 
 GITHUB_PROJECT = /github.com\/(?<account>.*?)\/(?<project>.*?)(\/|\Z)/
 
+def update_metadata(spec)
+	spec.metadata["bug_tracker_uri"] ||= detect_bug_tracker_uri(spec)
+	spec.metadata["changelog_uri"] ||= detect_changelog_uri(spec)
+	spec.metadata["documentation_uri"] ||= detect_documentation_uri(spec)
+	spec.metadata["funding_uri"] ||= detect_funding_uri(spec)
+	spec.metadata["source_code_uri"] ||= detect_source_code_uri(spec)
+end
+
 def normalize_homepage(spec)
 	if homepage = spec.homepage
 		spec.homepage = homepage.chomp("/")
 	end
 end
 
+def github_project(spec)
+	if homepage = spec.homepage
+		homepage.match(GITHUB_PROJECT)
+	end
+end
+
+def detect_bug_tracker_uri(spec)
+	if match = github_project(spec)
+		account = match[:account]
+		project = match[:project]
+		
+		return "https://github.com/#{account}/#{project}/issues"
+	end
+end
+
+def detect_changelog_uri(spec)
+	if match = github_project(spec)
+		account = match[:account]
+		project = match[:project]
+		root = File.dirname(spec.loaded_from)
+		
+		if File.exist?(File.expand_path("releases.md", root))
+			return "https://github.com/#{account}/#{project}/blob/main/releases.md"
+		end
+	end
+end
+
 def detect_funding_uri(spec)
-	if match = spec.homepage&.match(GITHUB_PROJECT)
+	if match = github_project(spec)
 		account = match[:account]
 		
 		funding_uri = "https://github.com/sponsors/#{account}/"
@@ -218,7 +251,7 @@ def detect_funding_uri(spec)
 end
 
 def detect_documentation_uri(spec)
-	if match = spec.homepage.match(GITHUB_PROJECT)
+	if match = github_project(spec)
 		account = match[:account]
 		project = match[:project]
 		
@@ -231,7 +264,7 @@ def detect_documentation_uri(spec)
 end
 
 def detect_source_code_uri(spec)
-	if match = spec.homepage.match(GITHUB_PROJECT)
+	if match = github_project(spec)
 		account = match[:account]
 		project = match[:project]
 		

--- a/bake/modernize/gemspec.rb
+++ b/bake/modernize/gemspec.rb
@@ -26,7 +26,7 @@ def update(path: default_gemspec_path, output: $stdout)
 	root = File.dirname(path)
 	version_path = version_path(root, spec.name)
 	
-	constant = File.read(version_path)
+	constant = File.read(File.join(root, version_path))
 		.scan(/(?:class|module)\s+(.*?)$/)
 		.flatten
 		.join("::")
@@ -35,7 +35,7 @@ def update(path: default_gemspec_path, output: $stdout)
 	
 	update_metadata(spec)
 	
-	spec.authors = sorted_authors(Dir.pwd)
+	spec.authors = sorted_authors(root)
 	
 	spec.metadata.delete_if{|_, value| value.nil?}
 	
@@ -104,7 +104,7 @@ def update(path: default_gemspec_path, output: $stdout)
 	
 	# Try to move development dependencies to `gems.rb`:
 	if spec.development_dependencies.any?
-		unless move_development_dependencies(spec.development_dependencies)
+		unless move_development_dependencies(spec.development_dependencies, root)
 			output.puts "\t"
 			spec.development_dependencies.sort.each do |dependency|
 				output.puts "\tspec.add_development_dependency #{format_dependency(dependency)}"
@@ -287,8 +287,8 @@ IGNORE_GEMS = %w[
 	bundler
 ].freeze
 
-def move_development_dependencies(dependencies)
-	gemfile_path = File.expand_path("gems.rb")
+def move_development_dependencies(dependencies, root = Dir.pwd)
+	gemfile_path = File.expand_path("gems.rb", root)
 	
 	if File.exist?(gemfile_path)
 		File.open(gemfile_path, "a") do |file|

--- a/bake/modernize/gemspec.rb
+++ b/bake/modernize/gemspec.rb
@@ -3,6 +3,8 @@
 # Released under the MIT License.
 # Copyright, 2020-2026, by Samuel Williams.
 
+require "bake/modernize"
+
 # Rewrite the current gemspec.
 def gemspec
 	path = default_gemspec_path
@@ -233,22 +235,11 @@ def detect_changelog_uri(spec)
 		root = File.dirname(spec.loaded_from)
 		
 		if File.exist?(File.expand_path("releases.md", root))
-			branch = current_branch(root) || "main"
+			branch = Bake::Modernize::Git.current_branch(root, default: "main")
 			
 			return "https://github.com/#{account}/#{project}/blob/#{branch}/releases.md"
 		end
 	end
-end
-
-def current_branch(root)
-	repository = Rugged::Repository.discover(root)
-	head = repository.head
-	
-	if head.branch?
-		return head.name.delete_prefix("refs/heads/")
-	end
-rescue Rugged::ReferenceError, Rugged::RepositoryError
-	# Fall back to the common default branch name when git metadata is unavailable.
 end
 
 def detect_funding_uri(spec)

--- a/bake/modernize/git.rb
+++ b/bake/modernize/git.rb
@@ -10,7 +10,7 @@ def git(root: Dir.pwd)
 end
 
 def update(root:)
-	if current_branch == "master"
+	if Bake::Modernize::Git.current_branch(root, default: nil) == "master"
 		# https://github.com/github/renaming
 		system("git", "branch", "-M", "main")
 		system("git", "push", "-u", "origin", "main")
@@ -41,16 +41,4 @@ def current_gitignore_custom_lines(root)
 			return lines
 		end
 	end
-end
-
-def current_branch
-	require "open3"
-	
-	output, status = Open3.capture2("git", "branch", "--show-current")
-	
-	unless status.success?
-		raise "Could not get current branch!"
-	end
-	
-	return output
 end

--- a/lib/bake/modernize.rb
+++ b/lib/bake/modernize.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2020-2025, by Samuel Williams.
+# Copyright, 2020-2026, by Samuel Williams.
 
+require_relative "modernize/git"
 require_relative "modernize/license"
 require_relative "modernize/version"
 

--- a/lib/bake/modernize/git.rb
+++ b/lib/bake/modernize/git.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "rugged"
+
+module Bake
+	module Modernize
+		# Utilities for inspecting git repositories.
+		module Git
+			# The current branch name for the repository at the given root.
+			def self.current_branch(root = Dir.pwd, default: nil)
+				begin
+					repository = Rugged::Repository.discover(root)
+					head = repository.head
+					
+					if head.branch?
+						return head.name.delete_prefix("refs/heads/")
+					end
+				rescue Rugged::ReferenceError, Rugged::RepositoryError
+				end
+				
+				return default
+			end
+		end
+	end
+end

--- a/test/bake/modernize.rb
+++ b/test/bake/modernize.rb
@@ -6,6 +6,7 @@
 require "bake"
 require "bake/context"
 require "bake/modernize"
+require "bake/modernize/git"
 require "sus/fixtures/temporary_directory_context"
 
 describe Bake::Modernize do
@@ -25,6 +26,10 @@ describe Bake::Modernize do
 		File.write(destination_path, "old")
 		
 		expect(Bake::Modernize.stale?(source_path, destination_path)).to be == true
+	end
+	
+	it "returns the default branch outside a git repository" do
+		expect(Bake::Modernize::Git.current_branch(root, default: "main")).to be == "main"
 	end
 	
 	it "updates documentation after a version increment" do

--- a/test/bake/modernize/gemspec.rb
+++ b/test/bake/modernize/gemspec.rb
@@ -14,7 +14,7 @@ describe "modernize:gemspec" do
 	let(:gemspec_path) {File.join(root, "example.gemspec")}
 	let(:output) {StringIO.new}
 	
-	def write_project(metadata = {})
+	def write_project(metadata = nil, branch: "main")
 		version_path = File.join(root, "lib", "example", "version.rb")
 		FileUtils.mkdir_p(File.dirname(version_path))
 		File.write(version_path, <<~RUBY)
@@ -27,7 +27,7 @@ describe "modernize:gemspec" do
 			"documentation_uri" => "https://socketry.github.io/example/",
 			"funding_uri" => "https://github.com/sponsors/socketry/",
 			"source_code_uri" => "https://github.com/socketry/example.git",
-		}.merge(metadata)
+		}.merge(metadata || {})
 		
 		File.write(gemspec_path, <<~RUBY)
 			# frozen_string_literal: true
@@ -55,7 +55,7 @@ describe "modernize:gemspec" do
 		signature = {name: "Samuel Williams", email: "samuel@example.com", time: Time.now}
 		tree = repository.index.write_tree(repository)
 		
-		Rugged::Commit.create(
+		commit_id = Rugged::Commit.create(
 			repository,
 			message: "Initial commit.",
 			author: signature,
@@ -64,6 +64,11 @@ describe "modernize:gemspec" do
 			tree: tree,
 			update_ref: "HEAD",
 		)
+		
+		unless repository.head.name == "refs/heads/#{branch}"
+			repository.branches.create(branch, commit_id)
+			repository.head = "refs/heads/#{branch}"
+		end
 	end
 	
 	def update_gemspec
@@ -84,13 +89,13 @@ describe "modernize:gemspec" do
 		expect(result).to be(:include?, %("bug_tracker_uri" => "https://github.com/socketry/example/issues"))
 	end
 	
-	it "adds changelog metadata when releases.md exists" do
-		write_project
+	it "adds changelog metadata using the current branch when releases.md exists" do
+		write_project(branch: "next")
 		File.write(File.join(root, "releases.md"), "# Releases\n")
 		
 		result = update_gemspec
 		
-		expect(result).to be(:include?, %("changelog_uri" => "https://github.com/socketry/example/blob/main/releases.md"))
+		expect(result).to be(:include?, %("changelog_uri" => "https://github.com/socketry/example/blob/next/releases.md"))
 	end
 	
 	it "does not add changelog metadata without releases.md" do
@@ -102,10 +107,10 @@ describe "modernize:gemspec" do
 	end
 	
 	it "preserves existing metadata" do
-		write_project(
+		write_project({
 			"bug_tracker_uri" => "https://example.com/issues",
 			"changelog_uri" => "https://example.com/changelog",
-		)
+		})
 		
 		result = update_gemspec
 		

--- a/test/bake/modernize/gemspec.rb
+++ b/test/bake/modernize/gemspec.rb
@@ -10,7 +10,7 @@ require "sus/fixtures/temporary_directory_context"
 describe "modernize:gemspec" do
 	include Sus::Fixtures::TemporaryDirectoryContext
 	
-	let(:context) {Bake::Context.load(Dir.pwd)}
+	let(:context) {Bake::Context.load}
 	let(:gemspec_path) {File.join(root, "example.gemspec")}
 	let(:output) {StringIO.new}
 	

--- a/test/bake/modernize/gemspec.rb
+++ b/test/bake/modernize/gemspec.rb
@@ -10,7 +10,7 @@ require "sus/fixtures/temporary_directory_context"
 describe "modernize:gemspec" do
 	include Sus::Fixtures::TemporaryDirectoryContext
 	
-	let(:context) {Bake::Context.load(File.expand_path("../../..", __dir__))}
+	let(:context) {Bake::Context.load(Dir.pwd)}
 	let(:gemspec_path) {File.join(root, "example.gemspec")}
 	let(:output) {StringIO.new}
 	

--- a/test/bake/modernize/gemspec.rb
+++ b/test/bake/modernize/gemspec.rb
@@ -6,11 +6,15 @@
 require "bake/context"
 require "bake/modernize"
 require "sus/fixtures/temporary_directory_context"
+require "tmpdir"
 
 describe "modernize:gemspec" do
 	include Sus::Fixtures::TemporaryDirectoryContext
 	
 	let(:context) {Bake::Context.load}
+	let(:task) {context.lookup("modernize:gemspec")}
+	let(:update_task) {context.lookup("modernize:gemspec:update")}
+	let(:recipe) {update_task.instance_variable_get(:@instance)}
 	let(:gemspec_path) {File.join(root, "example.gemspec")}
 	let(:output) {StringIO.new}
 	
@@ -72,13 +76,21 @@ describe "modernize:gemspec" do
 	end
 	
 	def update_gemspec
-		recipe = context.lookup("modernize:gemspec:update")
-		
-		Dir.chdir(root) do
-			recipe.call(path: gemspec_path, output: output)
-		end
+		update_task.call(path: gemspec_path, output: output)
 		
 		return output.string
+	end
+	
+	def build_spec(name: "example", homepage: "https://github.com/socketry/example")
+		Gem::Specification.new do |spec|
+			spec.name = name
+			spec.version = "1.0.0"
+			spec.summary = "An example gem."
+			spec.license = "MIT"
+			spec.homepage = homepage
+			spec.files = []
+			spec.loaded_from = gemspec_path
+		end
 	end
 	
 	it "adds GitHub bug tracker metadata" do
@@ -116,5 +128,155 @@ describe "modernize:gemspec" do
 		
 		expect(result).to be(:include?, %("bug_tracker_uri" => "https://example.com/issues"))
 		expect(result).to be(:include?, %("changelog_uri" => "https://example.com/changelog"))
+	end
+	
+	it "rewrites the default gemspec" do
+		write_project
+		
+		mock(recipe) do |mock|
+			mock.replace(:default_gemspec_path){gemspec_path}
+		end
+		
+		task.call
+		
+		expect(File.read(gemspec_path)).to be(:include?, "spec.version = Example::VERSION")
+	end
+	
+	it "emits optional gemspec fields" do
+		write_project
+		FileUtils.mkdir_p(File.join(root, "exe"))
+		FileUtils.mkdir_p(File.join(root, "ext"))
+		File.write(File.join(root, "release.cert"), "certificate")
+		File.write(File.join(root, ".rspec"), "--format documentation\n")
+		
+		File.write(gemspec_path, <<~RUBY)
+			# frozen_string_literal: true
+			
+			Gem::Specification.new do |spec|
+				spec.name = "example"
+				spec.version = "1.0.0"
+				spec.summary = "An example gem."
+				spec.authors = ["Samuel Williams"]
+				spec.license = "MIT"
+				spec.homepage = "https://github.com/socketry/example/"
+				spec.files = ["lib/example/version.rb", ".rspec"]
+				spec.require_paths = ["lib", "ext"]
+				spec.executables = ["example"]
+				spec.extensions = ["ext/example/extconf.rb"]
+				spec.add_dependency "console", "~> 1.0"
+				spec.add_dependency "json"
+				spec.add_development_dependency "sus", ">= 0"
+			end
+		RUBY
+		
+		result = update_gemspec
+		
+		expect(result).to be(:include?, "spec.cert_chain")
+		expect(result).to be(:include?, %(spec.homepage = "https://github.com/socketry/example"))
+		expect(result).to be(:include?, "File::FNM_DOTMATCH")
+		expect(result).to be(:include?, %(spec.require_paths = ["lib"]))
+		expect(result).to be(:include?, %(spec.executables = ["example"]))
+		expect(result).to be(:include?, %(spec.extensions = ["ext/example/extconf.rb"]))
+		expect(result).to be(:include?, %(spec.add_dependency "console", "~> 1.0"))
+		expect(result).to be(:include?, %(spec.add_dependency "json"))
+		expect(result).to be(:include?, %(spec.add_development_dependency "sus"))
+	end
+	
+	it "moves development dependencies to gems.rb" do
+		Dir.mktmpdir do |directory|
+			File.write(File.join(directory, "gems.rb"), "source \"https://rubygems.org\"\n")
+			dependencies = [
+				Gem::Dependency.new("bundler", ">= 0"),
+				Gem::Dependency.new("sus", "~> 0.37"),
+			]
+			
+			expect(recipe.send(:move_development_dependencies, dependencies, directory)).to be == true
+			
+			result = File.read(File.join(directory, "gems.rb"))
+			expect(result).to be(:include?, "# Moved Development Dependencies")
+			expect(result).to be(:include?, %(gem "sus", "~> 0.37"))
+			expect(result).not.to be(:include?, "bundler")
+		end
+	end
+	
+	it "formats bundler dependencies without requirements" do
+		dependency = Gem::Dependency.new("bundler", "~> 2.0")
+		
+		expect(recipe.send(:format_dependency, dependency)).to be == %("bundler")
+	end
+	
+	it "finds the default gemspec" do
+		expect(recipe.send(:default_gemspec_path)).to be == "bake-modernize.gemspec"
+	end
+	
+	it "selects the expected version path" do
+		FileUtils.mkdir_p(File.join(root, "lib", "example"))
+		FileUtils.mkdir_p(File.join(root, "lib", "other"))
+		File.write(File.join(root, "lib", "example", "version.rb"), "")
+		File.write(File.join(root, "lib", "other", "version.rb"), "")
+		
+		expect(recipe.send(:version_path, root, "example")).to be == "lib/example/version.rb"
+	end
+	
+	it "falls back to the shortest version path" do
+		FileUtils.mkdir_p(File.join(root, "lib", "a"))
+		FileUtils.mkdir_p(File.join(root, "lib", "much", "longer"))
+		File.write(File.join(root, "lib", "a", "version.rb"), "")
+		File.write(File.join(root, "lib", "much", "longer", "version.rb"), "")
+		
+		expect(recipe.send(:version_path, root, "missing")).to be == "lib/a/version.rb"
+	end
+	
+	it "detects optional GitHub metadata when URIs are valid" do
+		spec = build_spec
+		
+		mock(recipe) do |mock|
+			mock.replace(:valid_uri?){true}
+		end
+		
+		expect(recipe.send(:detect_funding_uri, spec)).to be == "https://github.com/sponsors/socketry/"
+		expect(recipe.send(:detect_documentation_uri, spec)).to be == "https://socketry.github.io/example/"
+	end
+	
+	it "ignores optional GitHub metadata when URIs are invalid" do
+		spec = build_spec
+		
+		mock(recipe) do |mock|
+			mock.replace(:valid_uri?){false}
+		end
+		
+		expect(recipe.send(:detect_funding_uri, spec)).to be_nil
+		expect(recipe.send(:detect_documentation_uri, spec)).to be_nil
+	end
+	
+	it "ignores GitHub metadata without a homepage" do
+		spec = build_spec(homepage: nil)
+		
+		expect(recipe.send(:github_project, spec)).to be_nil
+		expect(recipe.send(:detect_bug_tracker_uri, spec)).to be_nil
+		expect(recipe.send(:detect_source_code_uri, spec)).to be_nil
+		expect(recipe.send(:detect_changelog_uri, spec)).to be_nil
+		expect(recipe.send(:detect_funding_uri, spec)).to be_nil
+		expect(recipe.send(:detect_documentation_uri, spec)).to be_nil
+	end
+	
+	it "validates URIs with HTTP HEAD" do
+		requested_uri = nil
+		response = Object.new
+		response.define_singleton_method(:close){}
+		response.define_singleton_method(:success?){true}
+		
+		internet = Object.new
+		internet.define_singleton_method(:head) do |uri|
+			requested_uri = uri
+			response
+		end
+		
+		mock(Async::HTTP::Internet) do |mock|
+			mock.replace(:new){internet}
+		end
+		
+		expect(recipe.send(:valid_uri?, "https://example.com/")).to be == true
+		expect(requested_uri).to be == "https://example.com/"
 	end
 end

--- a/test/bake/modernize/gemspec.rb
+++ b/test/bake/modernize/gemspec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "bake/context"
+require "bake/modernize"
+require "sus/fixtures/temporary_directory_context"
+
+describe "modernize:gemspec" do
+	include Sus::Fixtures::TemporaryDirectoryContext
+	
+	let(:context) {Bake::Context.load(File.expand_path("../../..", __dir__))}
+	let(:gemspec_path) {File.join(root, "example.gemspec")}
+	let(:output) {StringIO.new}
+	
+	def write_project(metadata = {})
+		version_path = File.join(root, "lib", "example", "version.rb")
+		FileUtils.mkdir_p(File.dirname(version_path))
+		File.write(version_path, <<~RUBY)
+			module Example
+				VERSION = "1.0.0"
+			end
+		RUBY
+		
+		metadata = {
+			"documentation_uri" => "https://socketry.github.io/example/",
+			"funding_uri" => "https://github.com/sponsors/socketry/",
+			"source_code_uri" => "https://github.com/socketry/example.git",
+		}.merge(metadata)
+		
+		File.write(gemspec_path, <<~RUBY)
+			# frozen_string_literal: true
+			
+			Gem::Specification.new do |spec|
+				spec.name = "example"
+				spec.version = "1.0.0"
+				
+				spec.summary = "An example gem."
+				spec.authors = ["Samuel Williams"]
+				spec.license = "MIT"
+				
+				spec.homepage = "https://github.com/socketry/example"
+				
+				spec.metadata = #{metadata.inspect}
+				
+				spec.files = Dir["lib/**/*.rb", base: __dir__]
+			end
+		RUBY
+		
+		repository = Rugged::Repository.init_at(root)
+		repository.index.add_all
+		repository.index.write
+		
+		signature = {name: "Samuel Williams", email: "samuel@example.com", time: Time.now}
+		tree = repository.index.write_tree(repository)
+		
+		Rugged::Commit.create(
+			repository,
+			message: "Initial commit",
+			author: signature,
+			committer: signature,
+			parents: [],
+			tree: tree,
+			update_ref: "HEAD",
+		)
+	end
+	
+	def update_gemspec
+		recipe = context.lookup("modernize:gemspec:update")
+		
+		Dir.chdir(root) do
+			recipe.call(path: gemspec_path, output: output)
+		end
+		
+		return output.string
+	end
+	
+	it "adds GitHub bug tracker metadata" do
+		write_project
+		
+		result = update_gemspec
+		
+		expect(result).to be(:include?, %("bug_tracker_uri" => "https://github.com/socketry/example/issues"))
+	end
+	
+	it "adds changelog metadata when releases.md exists" do
+		write_project
+		File.write(File.join(root, "releases.md"), "# Releases\n")
+		
+		result = update_gemspec
+		
+		expect(result).to be(:include?, %("changelog_uri" => "https://github.com/socketry/example/blob/main/releases.md"))
+	end
+	
+	it "does not add changelog metadata without releases.md" do
+		write_project
+		
+		result = update_gemspec
+		
+		expect(result).not.to be(:include?, "changelog_uri")
+	end
+	
+	it "preserves existing metadata" do
+		write_project(
+			"bug_tracker_uri" => "https://example.com/issues",
+			"changelog_uri" => "https://example.com/changelog",
+		)
+		
+		result = update_gemspec
+		
+		expect(result).to be(:include?, %("bug_tracker_uri" => "https://example.com/issues"))
+		expect(result).to be(:include?, %("changelog_uri" => "https://example.com/changelog"))
+	end
+end

--- a/test/bake/modernize/gemspec.rb
+++ b/test/bake/modernize/gemspec.rb
@@ -57,7 +57,7 @@ describe "modernize:gemspec" do
 		
 		Rugged::Commit.create(
 			repository,
-			message: "Initial commit",
+			message: "Initial commit.",
 			author: signature,
 			committer: signature,
 			parents: [],


### PR DESCRIPTION
## Summary
- Infer GitHub bug tracker metadata for gemspecs.
- Infer changelog metadata when releases.md exists.
- Add Bake::Context-based coverage for generated gemspec metadata.

## Testing
- sus test/bake/modernize/gemspec.rb
- sus
- rubocop bake/modernize/gemspec.rb test/bake/modernize/gemspec.rb