### PR TITLE
Fix CI dependencies

### DIFF
--- a/.github/workflows/documentation-coverage.yaml
+++ b/.github/workflows/documentation-coverage.yaml
@@ -7,6 +7,7 @@ permissions:
 
 env:
   COVERAGE: PartialSummary
+  BUNDLE_WITH: maintenance
 
 jobs:
   validate:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,12 +26,6 @@ jobs:
         
         include:
           - os: ubuntu
-            ruby: truffleruby
-            experimental: true
-          - os: ubuntu
-            ruby: jruby
-            experimental: true
-          - os: ubuntu
             ruby: head
             experimental: true
     

--- a/bake/modernize/actions.rb
+++ b/bake/modernize/actions.rb
@@ -8,8 +8,8 @@ require "rugged"
 require "markly"
 require "build/files/system"
 
-def actions
-	update(root: Dir.pwd)
+def actions(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)

--- a/bake/modernize/copilot.rb
+++ b/bake/modernize/copilot.rb
@@ -6,8 +6,8 @@
 
 require "bake/modernize"
 
-def copilot
-	update(root: Dir.pwd)
+def copilot(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)

--- a/bake/modernize/editorconfig.rb
+++ b/bake/modernize/editorconfig.rb
@@ -5,8 +5,8 @@
 
 require "bake/modernize"
 
-def editorconfig
-	update(root: Dir.pwd)
+def editorconfig(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)

--- a/bake/modernize/gemfile.rb
+++ b/bake/modernize/gemfile.rb
@@ -5,8 +5,8 @@
 
 require "bake/modernize"
 
-def gemfile
-	update(root: Dir.pwd)
+def gemfile(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)

--- a/bake/modernize/git.rb
+++ b/bake/modernize/git.rb
@@ -5,8 +5,8 @@
 
 require "bake/modernize"
 
-def git
-	update(root: Dir.pwd)
+def git(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)

--- a/bake/modernize/license.rb
+++ b/bake/modernize/license.rb
@@ -27,8 +27,8 @@ SOFTWARE.
 LICENSE
 
 # @parameter root [String] The root directory to scan for changes.
-def license
-	update(root: Dir.pwd)
+def license(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)
@@ -121,4 +121,3 @@ def remove_license(readme_path)
 	
 	File.write(readme_path, root.to_markdown(width: 0))
 end
-

--- a/bake/modernize/readme.rb
+++ b/bake/modernize/readme.rb
@@ -6,8 +6,8 @@
 require "bake/modernize"
 require "build/files/system"
 
-def readme
-	update(root: Dir.pwd)
+def readme(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)

--- a/bake/modernize/releases.rb
+++ b/bake/modernize/releases.rb
@@ -39,7 +39,7 @@ def update_releases(readme_path)
 	if node
 		node.append_before(replacement)
 	else
-		root.append(replacement)
+		root.last_child.append_after(replacement)
 	end
 	
 	File.write(readme_path, root.to_markdown(width: 0))

--- a/bake/modernize/rubocop.rb
+++ b/bake/modernize/rubocop.rb
@@ -6,8 +6,8 @@
 require "bake/modernize"
 require "build/files/system"
 
-def rubocop
-	update(root: Dir.pwd)
+def rubocop(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)

--- a/bake/modernize/signing.rb
+++ b/bake/modernize/signing.rb
@@ -5,8 +5,8 @@
 
 require "bake/modernize"
 
-def signing
-	update(root: Dir.pwd)
+def signing(root: Dir.pwd)
+	update(root: root)
 end
 
 def update(root:)

--- a/lib/bake/modernize/license.rb
+++ b/lib/bake/modernize/license.rb
@@ -173,14 +173,20 @@ module Bake
 			class Authorship
 				# Represents a modification to a file.
 				Modification = Struct.new(:author, :time, :path, :id) do
+					# The full name of the author who made the modification.
+					# @returns [String] The author's display name.
 					def full_name
 						author[:name]
 					end
 					
+					# The stable key used to group modifications by commit or contribution.
+					# @returns [String] The modification key.
 					def key
 						self.id || "#{self.author[:email]}:#{self.time.iso8601}"
 					end
 					
+					# Convert the modification to a serializable hash.
+					# @returns [Hash] The modification data.
 					def to_h
 						{
 							id: id,
@@ -193,10 +199,15 @@ module Bake
 				
 				# Represents the copyright for an author.
 				Copyright = Struct.new(:dates, :author) do
+					# Compare copyrights by their dates and author.
+					# @parameter other [Copyright] The other copyright to compare.
+					# @returns [Integer] The comparison result.
 					def <=> other
 						self.to_a <=> other.to_a
 					end
 					
+					# Generate the copyright statement for the author.
+					# @returns [String] The formatted copyright statement.
 					def statement
 						years = self.dates.map(&:year).uniq
 						period = author.end_with?(".") ? "" : "."

--- a/test/bake/modernize.rb
+++ b/test/bake/modernize.rb
@@ -5,10 +5,24 @@
 
 require "bake"
 require "bake/context"
+require "bake/modernize"
+require "sus/fixtures/temporary_directory_context"
 
 describe Bake::Modernize do
+	include Sus::Fixtures::TemporaryDirectoryContext
+	
 	it "has a version number" do
 		expect(Bake::Modernize::VERSION).to be =~ /^\d+\.\d+\.\d+$/
+	end
+	
+	it "detects stale files when the destination exists" do
+		source_path = File.join(root, "source.txt")
+		destination_path = File.join(root, "destination.txt")
+		
+		File.write(source_path, "new")
+		File.write(destination_path, "old")
+		
+		expect(Bake::Modernize.stale?(source_path, destination_path)).to be == true
 	end
 	
 	# let(:context) {Bake::Context.load}

--- a/test/bake/modernize.rb
+++ b/test/bake/modernize.rb
@@ -8,10 +8,10 @@ require "bake/context"
 require "bake/modernize"
 require "sus/fixtures/temporary_directory_context"
 
-require_relative "../../bake"
-
 describe Bake::Modernize do
 	include Sus::Fixtures::TemporaryDirectoryContext
+	
+	let(:context) {Bake::Context.load}
 	
 	it "has a version number" do
 		expect(Bake::Modernize::VERSION).to be =~ /^\d+\.\d+\.\d+$/
@@ -29,20 +29,22 @@ describe Bake::Modernize do
 	
 	it "updates documentation after a version increment" do
 		calls = []
-		context = Object.new
-		context.define_singleton_method(:[]) do |name|
+		call_context = Object.new
+		call_context.define_singleton_method(:[]) do |name|
 			Object.new.tap do |callable|
 				callable.define_singleton_method(:call) do |*arguments|
 					calls << [name, arguments]
 				end
 			end
 		end
+		task = context.lookup("after_gem_release_version_increment")
+		recipe = task.instance_variable_get(:@instance)
 		
-		mock(self) do |mock|
-			mock.replace(:context){context}
+		mock(recipe) do |mock|
+			mock.replace(:context){call_context}
 		end
 		
-		after_gem_release_version_increment("1.2.3")
+		task.call("1.2.3")
 		
 		expect(calls).to be == [
 			["releases:update", ["1.2.3"]],
@@ -52,27 +54,23 @@ describe Bake::Modernize do
 	
 	it "creates GitHub releases after gem release" do
 		calls = []
-		context = Object.new
-		context.define_singleton_method(:[]) do |name|
+		call_context = Object.new
+		call_context.define_singleton_method(:[]) do |name|
 			Object.new.tap do |callable|
 				callable.define_singleton_method(:call) do |*arguments|
 					calls << [name, arguments]
 				end
 			end
 		end
+		task = context.lookup("after_gem_release")
+		recipe = task.instance_variable_get(:@instance)
 		
-		mock(self) do |mock|
-			mock.replace(:context){context}
+		mock(recipe) do |mock|
+			mock.replace(:context){call_context}
 		end
 		
-		after_gem_release(tag: "v1.2.3")
+		task.call(tag: "v1.2.3")
 		
 		expect(calls).to be == [["releases:github:release", ["v1.2.3"]]]
 	end
-	
-	# let(:context) {Bake::Context.load}
-	
-	# it "can modernize itself" do
-	# 	context.call('modernize')
-	# end
 end

--- a/test/bake/modernize.rb
+++ b/test/bake/modernize.rb
@@ -8,6 +8,8 @@ require "bake/context"
 require "bake/modernize"
 require "sus/fixtures/temporary_directory_context"
 
+require_relative "../../bake"
+
 describe Bake::Modernize do
 	include Sus::Fixtures::TemporaryDirectoryContext
 	
@@ -23,6 +25,49 @@ describe Bake::Modernize do
 		File.write(destination_path, "old")
 		
 		expect(Bake::Modernize.stale?(source_path, destination_path)).to be == true
+	end
+	
+	it "updates documentation after a version increment" do
+		calls = []
+		context = Object.new
+		context.define_singleton_method(:[]) do |name|
+			Object.new.tap do |callable|
+				callable.define_singleton_method(:call) do |*arguments|
+					calls << [name, arguments]
+				end
+			end
+		end
+		
+		mock(self) do |mock|
+			mock.replace(:context){context}
+		end
+		
+		after_gem_release_version_increment("1.2.3")
+		
+		expect(calls).to be == [
+			["releases:update", ["1.2.3"]],
+			["utopia:project:update", []],
+		]
+	end
+	
+	it "creates GitHub releases after gem release" do
+		calls = []
+		context = Object.new
+		context.define_singleton_method(:[]) do |name|
+			Object.new.tap do |callable|
+				callable.define_singleton_method(:call) do |*arguments|
+					calls << [name, arguments]
+				end
+			end
+		end
+		
+		mock(self) do |mock|
+			mock.replace(:context){context}
+		end
+		
+		after_gem_release(tag: "v1.2.3")
+		
+		expect(calls).to be == [["releases:github:release", ["v1.2.3"]]]
 	end
 	
 	# let(:context) {Bake::Context.load}

--- a/test/bake/modernize/copilot.rb
+++ b/test/bake/modernize/copilot.rb
@@ -6,21 +6,14 @@
 
 require "sus/fixtures/temporary_directory_context"
 require "bake/context"
-require_relative "../../../bake/modernize/copilot"
 
 describe "modernize:copilot" do
 	include Sus::Fixtures::TemporaryDirectoryContext
 	
-	it "can be invoked with a root path" do
-		context = Bake::Context.load
-		context.lookup("modernize:copilot").call(root: root)
-		
-		copilot_file = File.join(root, ".github", "copilot-instructions.md")
-		expect(File.exist?(copilot_file)).to be_truthy
-	end
+	let(:context) {Bake::Context.load}
 	
-	it "creates copilot-instructions.md file" do
-		update(root: root)
+	it "can be invoked with a root path" do
+		context.lookup("modernize:copilot").call(root: root)
 		
 		copilot_file = File.join(root, ".github", "copilot-instructions.md")
 		expect(File.exist?(copilot_file)).to be_truthy

--- a/test/bake/modernize/copilot.rb
+++ b/test/bake/modernize/copilot.rb
@@ -10,6 +10,15 @@ require_relative "../../../bake/modernize/copilot"
 describe "modernize:copilot" do
 	include Sus::Fixtures::TemporaryDirectoryContext
 	
+	it "uses the current directory by default" do
+		Dir.chdir(root) do
+			copilot
+		end
+		
+		copilot_file = File.join(root, ".github", "copilot-instructions.md")
+		expect(File.exist?(copilot_file)).to be_truthy
+	end
+	
 	it "creates copilot-instructions.md file" do
 		update(root: root)
 		

--- a/test/bake/modernize/copilot.rb
+++ b/test/bake/modernize/copilot.rb
@@ -5,15 +5,15 @@
 # Copyright, 2025-2026, by Samuel Williams.
 
 require "sus/fixtures/temporary_directory_context"
+require "bake/context"
 require_relative "../../../bake/modernize/copilot"
 
 describe "modernize:copilot" do
 	include Sus::Fixtures::TemporaryDirectoryContext
 	
-	it "uses the current directory by default" do
-		Dir.chdir(root) do
-			copilot
-		end
+	it "can be invoked with a root path" do
+		context = Bake::Context.load
+		context.lookup("modernize:copilot").call(root: root)
 		
 		copilot_file = File.join(root, ".github", "copilot-instructions.md")
 		expect(File.exist?(copilot_file)).to be_truthy

--- a/test/bake/modernize/license.rb
+++ b/test/bake/modernize/license.rb
@@ -4,9 +4,44 @@
 # Copyright, 2023-2025, by Samuel Williams.
 
 require "bake/modernize/license"
+require "sus/fixtures/temporary_directory_context"
+
+describe Bake::Modernize::License::SkipList do
+	include Sus::Fixtures::TemporaryDirectoryContext
+	
+	let(:path) {File.join(root, Bake::Modernize::License::GIT_BLAME_IGNORE_REVS)}
+	
+	it "loads revisions from a directory" do
+		File.write(path, "# Comment\n\nabc123\n")
+		
+		skip_list = subject.for(root)
+		commit = Struct.new(:oid).new("abc123")
+		
+		expect(skip_list.ignore?(commit)).to be == true
+	end
+	
+	it "returns nil when no skip list exists" do
+		expect(subject.for(root)).to be_nil
+	end
+end
 
 describe Bake::Modernize::License::Mailmap do
+	include Sus::Fixtures::TemporaryDirectoryContext
+	
 	let(:mailmap) {subject.new}
+	let(:path) {File.join(root, ".mailmap")}
+	
+	it "loads mailmap entries from a directory" do
+		File.write(path, "# Comment\n\nSamuel Williams <samuel@example.org> <ioquatix@example.org>\n")
+		
+		mailmap = subject.for(root)
+		
+		expect(mailmap.names["ioquatix@example.org"]).to be == "Samuel Williams"
+	end
+	
+	it "returns nil when no mailmap exists" do
+		expect(subject.for(root)).to be_nil
+	end
 	
 	it "can parse a proper name and commit email" do
 		user = mailmap.extract_from_line("Samuel Williams <samuel@example.org>")
@@ -34,8 +69,30 @@ describe Bake::Modernize::License::Mailmap do
 end
 
 describe Bake::Modernize::License::Contributors do
+	include Sus::Fixtures::TemporaryDirectoryContext
+	
 	let(:mailmap) {Bake::Modernize::License::Mailmap.new}
 	let(:contributors) {subject.new(mailmap: mailmap)}
+	let(:path) {File.join(root, ".contributors.yaml")}
+	
+	it "loads contributors from a directory" do
+		File.write(path, <<~YAML)
+			---
+			- author:
+			    name: Jane Doe
+			    email: jane@example.com
+			  time: 2026-01-01 00:00:00 UTC
+		YAML
+		
+		contributors = subject.for(root, mailmap: mailmap)
+		paths = contributors.paths_for(contributors.contributions.first).to_a
+		
+		expect(paths).to be == ["."]
+	end
+	
+	it "returns nil when no contributors file exists" do
+		expect(subject.for(root, mailmap: mailmap)).to be_nil
+	end
 	
 	it "can iterate over contributions without mailmap" do
 		contributors_without_mailmap = subject.new
@@ -123,6 +180,30 @@ describe Bake::Modernize::License::Contributors do
 	end
 end
 
+describe Bake::Modernize::License::Authorship::Modification do
+	let(:author) {{name: "Samuel Williams", email: "samuel@example.com"}}
+	let(:time) {Time.new(2026, 1, 1, 0, 0, 0, "+00:00")}
+	
+	it "provides author and serialization helpers" do
+		modification = subject.new(author, time, "lib/example.rb", nil)
+		
+		expect(modification.full_name).to be == "Samuel Williams"
+		expect(modification.key).to be == "samuel@example.com:2026-01-01T00:00:00+00:00"
+		expect(modification.to_h).to be == {
+			id: nil,
+			time: time,
+			path: "lib/example.rb",
+			author: author,
+		}
+	end
+	
+	it "uses an explicit id as the key" do
+		modification = subject.new(author, time, "lib/example.rb", "commit-id")
+		
+		expect(modification.key).to be == "commit-id"
+	end
+end
+
 describe Bake::Modernize::License::Authorship::Copyright do
 	it "adds period when author doesn't end with one" do
 		copyright = subject.new([Time.new(2023), Time.new(2024)], "Samuel Williams")
@@ -134,5 +215,72 @@ describe Bake::Modernize::License::Authorship::Copyright do
 		copyright = subject.new([Time.new(2023), Time.new(2024)], "Widgets Inc.")
 		
 		expect(copyright.statement).to be == "Copyright, 2023-2024, by Widgets Inc."
+	end
+	
+	it "sorts by date and author" do
+		first = subject.new([Time.new(2023)], "A Person")
+		second = subject.new([Time.new(2024)], "B Person")
+		
+		expect(first <=> second).to be == -1
+	end
+end
+
+describe Bake::Modernize::License::Authorship do
+	include Sus::Fixtures::TemporaryDirectoryContext
+	
+	let(:authorship) {subject.new}
+	let(:time) {Time.new(2026, 1, 1, 0, 0, 0, "+00:00")}
+	let(:author) {{name: "Samuel Williams", email: "samuel@example.com"}}
+	
+	def write_commit(repository, path, content, author:, message: "Commit.")
+		full_path = File.join(repository.workdir, path)
+		FileUtils.mkdir_p(File.dirname(full_path))
+		File.write(full_path, content)
+		
+		repository.index.add_all
+		repository.index.write
+		
+		parents = repository.empty? ? [] : [repository.head.target]
+		tree = repository.index.write_tree(repository)
+		
+		Rugged::Commit.create(
+			repository,
+			message: message,
+			author: author,
+			committer: author,
+			parents: parents,
+			tree: tree,
+			update_ref: "HEAD",
+		)
+	end
+	
+	it "adds modifications and summarizes authors" do
+		authorship.add("lib/example.rb", author, time)
+		
+		expect(authorship.sorted_authors).to be == ["Samuel Williams"]
+		expect(authorship.copyrights.map(&:statement)).to be == ["Copyright, 2026, by Samuel Williams."]
+		expect(authorship.copyrights_for_path("lib/example.rb").map(&:statement)).to be == ["Copyright, 2026, by Samuel Williams."]
+	end
+	
+	it "extracts authorship from contributors and git history" do
+		File.write(File.join(root, ".contributors.yaml"), [{
+			author: {name: "Contributor Name", email: "contributor@example.com"},
+			time: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
+			path: "README.md",
+		}].to_yaml)
+		File.write(File.join(root, ".mailmap"), "Samuel Williams <samuel@example.com> <old@example.com>\n")
+		
+		repository = Rugged::Repository.init_at(root)
+		commit_author = {name: "Old Name", email: "old@example.com", time: time}
+		write_commit(repository, "lib/example.rb", "example\n", author: commit_author)
+		FileUtils.rm(File.join(root, "lib", "example.rb"))
+		write_commit(repository, "lib/renamed.rb", "example\n", author: commit_author)
+		
+		result = authorship.extract(root)
+		
+		expect(result).to be == authorship
+		expect(authorship.sorted_authors).to be(:include?, "Samuel Williams")
+		expect(authorship.sorted_authors).to be(:include?, "Contributor Name")
+		expect(authorship.paths).to be(:include?, "lib/renamed.rb")
 	end
 end

--- a/test/bake/modernize/releases.rb
+++ b/test/bake/modernize/releases.rb
@@ -5,14 +5,17 @@
 
 require "sus/fixtures/async/reactor_context"
 require "sus/fixtures/temporary_directory_context"
+require "bake/context"
 
 require "async/ollama"
-
-require_relative "../../../bake/modernize/releases"
 
 describe "modernize:releases" do
 	include Sus::Fixtures::Async::ReactorContext
 	include Sus::Fixtures::TemporaryDirectoryContext
+	
+	let(:context) {Bake::Context.load}
+	let(:task) {context.lookup("modernize:releases")}
+	let(:recipe) {task.instance_variable_get(:@instance)}
 	
 	let(:bake_path) {File.join(root, "bake.rb")}
 	let(:releases_md_path) {File.join(root, "releases.md")}
@@ -21,7 +24,7 @@ describe "modernize:releases" do
 	it "updates the release project files" do
 		File.write(readme_path, "# Example\n")
 		
-		mock(self) do |mock|
+		mock(recipe) do |mock|
 			mock.replace(:system) do |*arguments, chdir: nil|
 				expect(arguments).to be == ["bundle", "add", "bake-releases", "--group", "maintenance"]
 				expect(chdir).to be == root
@@ -34,7 +37,7 @@ describe "modernize:releases" do
 			end
 		end
 		
-		releases(root: root)
+		task.call(root: root)
 		
 		expect(File.read(readme_path)).to be =~ /## Releases/
 		expect(File.exist?(releases_md_path)).to be_truthy
@@ -45,7 +48,7 @@ describe "modernize:releases" do
 		content = "# Example\n\n## Releases\n\nExisting release notes.\n"
 		File.write(readme_path, content)
 		
-		update_releases(readme_path)
+		recipe.send(:update_releases, readme_path)
 		
 		expect(File.read(readme_path)).to be == content
 	end
@@ -53,7 +56,7 @@ describe "modernize:releases" do
 	it "adds releases before see also" do
 		File.write(readme_path, "# Example\n\n## See Also\n\n- Other projects.\n")
 		
-		update_releases(readme_path)
+		recipe.send(:update_releases, readme_path)
 		
 		result = File.read(readme_path)
 		expect(result.index("## Releases")).to be < result.index("## See Also")
@@ -62,14 +65,14 @@ describe "modernize:releases" do
 	it "adds releases before contributing" do
 		File.write(readme_path, "# Example\n\n## Contributing\n\n- Send patches.\n")
 		
-		update_releases(readme_path)
+		recipe.send(:update_releases, readme_path)
 		
 		result = File.read(readme_path)
 		expect(result.index("## Releases")).to be < result.index("## Contributing")
 	end
 	
 	it "creates releases.md when it does not exist" do
-		update_releases_md(releases_md_path)
+		recipe.send(:update_releases_md, releases_md_path)
 		
 		expect(File.exist?(releases_md_path)).to be_truthy
 		expect(File.read(releases_md_path)).to be =~ /Unreleased/
@@ -79,13 +82,13 @@ describe "modernize:releases" do
 		existing_content = "# Releases\n\n## v1.0.0\n\n- Initial release\n"
 		File.write(releases_md_path, existing_content)
 		
-		update_releases_md(releases_md_path)
+		recipe.send(:update_releases_md, releases_md_path)
 		
 		expect(File.read(releases_md_path)).to be == existing_content
 	end
 	
 	it "creates bake.rb from template when none exists" do
-		update_bake(root)
+		recipe.send(:update_bake, root)
 		
 		expect(File.exist?(bake_path)).to be_truthy
 		expect(File.read(bake_path)).to be =~ /after_gem_release/
@@ -123,7 +126,7 @@ describe "modernize:releases" do
 			end
 		end
 		
-		update_bake(root)
+		recipe.send(:update_bake, root)
 		
 		result = File.read(bake_path)
 		

--- a/test/bake/modernize/releases.rb
+++ b/test/bake/modernize/releases.rb
@@ -6,6 +6,8 @@
 require "sus/fixtures/async/reactor_context"
 require "sus/fixtures/temporary_directory_context"
 
+require "async/ollama"
+
 require_relative "../../../bake/modernize/releases"
 
 describe "modernize:releases" do
@@ -47,6 +49,28 @@ describe "modernize:releases" do
 			end
 		RUBY
 		File.write(bake_path, existing)
+		
+		mock(Async::Ollama::Transform) do |mock|
+			mock.replace(:call) do |content, model:, instruction:, template:|
+				expect(content).to be == existing
+				expect(model).to be == "qwen3-coder:latest"
+				expect(instruction).to be(:include?, "Merge the template")
+				expect(template).to be(:include?, "def after_gem_release")
+				
+				<<~RUBY
+					# frozen_string_literal: true
+					
+					def after_gem_release_version_increment(version)
+						context["utopia:project:update"].call
+						context["releases:update"].call(version)
+					end
+					
+					def after_gem_release(tag:, **options)
+						context["releases:github:release"].call(tag)
+					end
+				RUBY
+			end
+		end
 		
 		update_bake(root)
 		

--- a/test/bake/modernize/releases.rb
+++ b/test/bake/modernize/releases.rb
@@ -16,6 +16,57 @@ describe "modernize:releases" do
 	
 	let(:bake_path) {File.join(root, "bake.rb")}
 	let(:releases_md_path) {File.join(root, "releases.md")}
+	let(:readme_path) {File.join(root, "readme.md")}
+	
+	it "updates the release project files" do
+		File.write(readme_path, "# Example\n")
+		
+		mock(self) do |mock|
+			mock.replace(:system) do |*arguments, chdir: nil|
+				expect(arguments).to be == ["bundle", "add", "bake-releases", "--group", "maintenance"]
+				expect(chdir).to be == root
+				true
+			end
+			
+			mock.replace(:update_bake) do |path|
+				expect(path).to be == root
+				File.write(bake_path, "# frozen_string_literal: true\n")
+			end
+		end
+		
+		releases(root: root)
+		
+		expect(File.read(readme_path)).to be =~ /## Releases/
+		expect(File.exist?(releases_md_path)).to be_truthy
+		expect(File.exist?(bake_path)).to be_truthy
+	end
+	
+	it "does not add releases to a readme that already has them" do
+		content = "# Example\n\n## Releases\n\nExisting release notes.\n"
+		File.write(readme_path, content)
+		
+		update_releases(readme_path)
+		
+		expect(File.read(readme_path)).to be == content
+	end
+	
+	it "adds releases before see also" do
+		File.write(readme_path, "# Example\n\n## See Also\n\n- Other projects.\n")
+		
+		update_releases(readme_path)
+		
+		result = File.read(readme_path)
+		expect(result.index("## Releases")).to be < result.index("## See Also")
+	end
+	
+	it "adds releases before contributing" do
+		File.write(readme_path, "# Example\n\n## Contributing\n\n- Send patches.\n")
+		
+		update_releases(readme_path)
+		
+		result = File.read(readme_path)
+		expect(result.index("## Releases")).to be < result.index("## Contributing")
+	end
 	
 	it "creates releases.md when it does not exist" do
 		update_releases_md(releases_md_path)


### PR DESCRIPTION
## Summary
- Mock the Ollama transform in the releases test so CI does not require a local Ollama server.
- Install the optional maintenance bundle group for documentation coverage so decode tasks are available.

## Testing
- sus test/bake/modernize/releases.rb
- rubocop test/bake/modernize/releases.rb
- sus

Note: Could not verify bundle exec bake decode:index:coverage lib locally because the local Bundler environment is missing several locked gems.